### PR TITLE
Enable edns0 for larger UDP responses

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -64,9 +64,11 @@ impl Resolver {
         sources: impl IntoIterator<Item = SocketAddr>,
         local: Option<SocketAddr>,
     ) -> Self {
+        let mut opts = ResolverOpts::default();
+        opts.edns0 = true;
         Self(TokioAsyncResolver::tokio(
             Self::config(sources.into_iter(), local),
-            ResolverOpts::default(),
+            opts,
         ))
     }
 


### PR DESCRIPTION
It looks like you need to specifically enable `edns0` in the `ResolverOpts` since it's not set by default. Without it you can run into issues when querying fly.io for various TXT records since it's possible that the responses will be larger than 512 bytes. Without this set, you'll get obscure errors, ex. `rdata length too large for remaining bytes`.